### PR TITLE
Some Quic PR updates 

### DIFF
--- a/libp2p/build.gradle.kts
+++ b/libp2p/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation("io.netty:netty-handler")
     implementation("io.netty:netty-codec-http")
     implementation("io.netty:netty-transport-classes-epoll:4.1.90.Final")
+    implementation("io.netty.incubator:netty-incubator-codec-native-quic")
 
     api("com.google.protobuf:protobuf-java")
 

--- a/libp2p/build.gradle.kts
+++ b/libp2p/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
     api("io.netty:netty-transport")
     implementation("io.netty:netty-handler")
     implementation("io.netty:netty-codec-http")
-    implementation("io.netty.incubator:netty-incubator-codec-native-quic:0.0.38.Final:linux-x86_64")
     implementation("io.netty:netty-transport-classes-epoll:4.1.90.Final")
 
     api("com.google.protobuf:protobuf-java")
@@ -22,6 +21,12 @@ dependencies {
     implementation("org.bouncycastle:bctls-jdk15on")
 
     testImplementation(project(":tools:schedulers"))
+
+    testImplementation("io.netty.incubator:netty-incubator-codec-native-quic::linux-x86_64")
+    testImplementation("io.netty.incubator:netty-incubator-codec-native-quic::linux-aarch_64")
+    testImplementation("io.netty.incubator:netty-incubator-codec-native-quic::osx-x86_64")
+    testImplementation("io.netty.incubator:netty-incubator-codec-native-quic::osx-aarch_64")
+    testImplementation("io.netty.incubator:netty-incubator-codec-native-quic::windows-x86_64")
 
     testFixturesApi("org.apache.logging.log4j:log4j-core")
     testFixturesImplementation(project(":tools:schedulers"))

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicPingTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicPingTestJava.java
@@ -18,7 +18,7 @@ import java.util.concurrent.*;
 
 public class QuicPingTestJava {
     @Test
-//    @Disabled
+    @Disabled
     void ping() throws Exception {
         PeerId peerId = PeerId.fromBase58(getKuboPeerId());
 

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicPingTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicPingTestJava.java
@@ -1,5 +1,9 @@
-package io.libp2p.core;
+package io.libp2p.transport.quic;
 
+import io.libp2p.core.Host;
+import io.libp2p.core.PeerId;
+import io.libp2p.core.Stream;
+import io.libp2p.core.StreamPromise;
 import io.libp2p.core.crypto.*;
 import io.libp2p.core.dsl.*;
 import io.libp2p.core.multiformats.*;

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
@@ -19,7 +19,7 @@ import java.util.concurrent.*;
 
 public class QuicServerTestJava {
     @Test
-//    @Disabled
+    @Disabled
     void ping() throws Exception {
         String localListenAddress = "/ip4/127.0.0.1/udp/40002/quic";
 //        String localListenAddress = "/ip4/127.0.0.1/tcp/40002";

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
@@ -1,5 +1,9 @@
-package io.libp2p.core;
+package io.libp2p.transport.quic;
 
+import io.libp2p.core.Host;
+import io.libp2p.core.PeerId;
+import io.libp2p.core.Stream;
+import io.libp2p.core.StreamPromise;
 import io.libp2p.core.crypto.*;
 import io.libp2p.core.dsl.*;
 import io.libp2p.core.multiformats.*;
@@ -15,7 +19,7 @@ import java.util.concurrent.*;
 
 public class QuicServerTestJava {
     @Test
-    @Disabled
+//    @Disabled
     void ping() throws Exception {
         String localListenAddress = "/ip4/127.0.0.1/udp/40002/quic";
 //        String localListenAddress = "/ip4/127.0.0.1/tcp/40002";

--- a/libp2p/src/testFixtures/java/io/libp2p/core/QuicPingTestJava.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/core/QuicPingTestJava.java
@@ -14,12 +14,12 @@ import java.util.concurrent.*;
 
 public class QuicPingTestJava {
     @Test
-    @Disabled
+//    @Disabled
     void ping() throws Exception {
         PeerId peerId = PeerId.fromBase58(getKuboPeerId());
 
         Host clientHost = new HostBuilder()
-                .secureTransport(QuicTransport::Ed25519)
+                .secureTransport(QuicTransport::Ecdsa)
                 .build();
 
         CompletableFuture<Void> clientStarted = clientHost.start();

--- a/versions.gradle
+++ b/versions.gradle
@@ -42,5 +42,6 @@ dependencyManagement {
             entry 'bcpkix-jdk15on'
             entry 'bctls-jdk15on'
         }
+        dependency "io.netty.incubator:netty-incubator-codec-native-quic:0.0.38.Final"
     }
 }


### PR DESCRIPTION
Updates for https://github.com/libp2p/jvm-libp2p/pull/294

- Extract Quic library version to `versions.gradle`.
- Move tests from `testFixtures` to `test`
- Include quic native libraries for all platforms (for test module only). 

I'm not sure how to correctly avoid including all the Quic native libs when you need just one platform for your project. 
We could potentially rely this responsibility on the user build and just include all platforms for test only 
