### PR TITLE
Quick PR refactor 

### DIFF
--- a/libp2p/src/main/java/io/libp2p/core/dsl/HostBuilder.java
+++ b/libp2p/src/main/java/io/libp2p/core/dsl/HostBuilder.java
@@ -59,13 +59,18 @@ public class HostBuilder {
 
   @SafeVarargs
   public final HostBuilder secureTransport(
-      BiFunction<PrivKey, List<ProtocolBinding<?>>, Transport>... transports) {
+      BiFunction<PrivKey, List<? extends ProtocolBinding<?>>, Transport>... transports) {
     secureTransports_.addAll(Arrays.asList(transports));
     return this;
   }
 
   public final HostBuilder listen(String... addresses) {
     listenAddresses_.addAll(Arrays.asList(addresses));
+    return this;
+  }
+
+  public HostBuilder keyType(KeyType keyType) {
+    this.keyType = keyType;
     return this;
   }
 
@@ -79,20 +84,9 @@ public class HostBuilder {
     return BuilderJKt.hostJ(
         defaultMode_.asBuilderDefault(),
         b -> {
-          IdentityBuilder identity = b.getIdentity();
-          identity.random(KeyType.ED25519);
-          PrivKey peerId = identity.getFactory().invoke();
-          identity.setFactory(() -> peerId);
+          b.getIdentity().random(keyType);
 
-          secureTransports_.forEach(
-              st ->
-                  b.getSecureTransports()
-                      .add(
-                          p ->
-                              u ->
-                                  st.apply(
-                                      identity.getFactory().invoke(),
-                                      (List<ProtocolBinding<?>>) p)));
+          secureTransports_.forEach(st -> b.getSecureTransports().add(st::apply));
           transports_.forEach(t -> b.getTransports().add(t::apply));
           secureChannels_.forEach(
               sc -> b.getSecureChannels().add((k, m) -> sc.apply(k, (List<StreamMuxer>) m)));
@@ -104,8 +98,9 @@ public class HostBuilder {
   } // build
 
   private DefaultMode defaultMode_;
-  private List<BiFunction<PrivKey, List<ProtocolBinding<?>>, Transport>> secureTransports_ =
-      new ArrayList<>();
+  private KeyType keyType = KeyType.ECDSA;
+  private List<BiFunction<PrivKey, List<? extends ProtocolBinding<?>>, Transport>>
+      secureTransports_ = new ArrayList<>();
 
   private List<Function<ConnectionUpgrader, Transport>> transports_ = new ArrayList<>();
   private List<BiFunction<PrivKey, List<StreamMuxer>, SecureChannel>> secureChannels_ =

--- a/libp2p/src/main/kotlin/io/libp2p/core/dsl/Builders.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/dsl/Builders.kt
@@ -191,8 +191,12 @@ open class Builder {
 
         val upgrader = ConnectionUpgrader(secureMultistreamProtocol, secureChannels, muxerMultistreamProtocol, muxers)
 
-        val secureTransports = secureTransports.values.map { it(privKey, updatableProtocols) }
-        val transports = transports.values.map { it(upgrader) } + secureTransports
+        val allTransports =
+            listOf(
+                transports.values.map { it(upgrader) },
+                secureTransports.values.map { it(privKey, updatableProtocols) }
+            ).flatten()
+
         val addressBook = addressBook.impl
 
         val connHandlerProtocols = protocols.values.mapNotNull { it as? ConnectionHandler }
@@ -200,7 +204,7 @@ open class Builder {
             connHandlerProtocols +
                 connectionHandlers.values
         )
-        val networkImpl = NetworkImpl(transports, broadcastConnHandler)
+        val networkImpl = NetworkImpl(allTransports, broadcastConnHandler)
 
         return HostImpl(
             privKey,

--- a/libp2p/src/main/kotlin/io/libp2p/core/dsl/Builders.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/dsl/Builders.kt
@@ -37,7 +37,7 @@ import io.netty.handler.logging.LoggingHandler
 import java.util.concurrent.CopyOnWriteArrayList
 
 typealias TransportCtor = (ConnectionUpgrader) -> Transport
-typealias SecureTransportCtor = (List<ProtocolBinding<Any>>) -> TransportCtor
+typealias SecureTransportCtor = (PrivKey, List<ProtocolBinding<*>>) -> Transport
 typealias SecureChannelCtor = (PrivKey, List<StreamMuxer>) -> SecureChannel
 typealias IdentityFactory = () -> PrivKey
 
@@ -58,8 +58,8 @@ open class Builder {
     protected open val identity = IdentityBuilder()
     protected open val secureChannels = SecureChannelsBuilder()
     protected open val muxers = MuxersBuilder()
-    protected open val secureTransports = SecureTransportsBuilder()
     protected open val transports = TransportsBuilder()
+    protected open val secureTransports = SecureTransportsBuilder()
     protected open val addressBook = AddressBookBuilder()
     protected open val protocols = ProtocolsBuilder()
     protected open val connectionHandlers = ConnectionHandlerBuilder()
@@ -191,9 +191,8 @@ open class Builder {
 
         val upgrader = ConnectionUpgrader(secureMultistreamProtocol, secureChannels, muxerMultistreamProtocol, muxers)
 
-        val secureTransports = secureTransports.values.map { it(updatableProtocols) }
-        transports.addAll(secureTransports)
-        val transports = transports.values.map { it(upgrader) }
+        val secureTransports = secureTransports.values.map { it(privKey, updatableProtocols) }
+        val transports = transports.values.map { it(upgrader) } + secureTransports
         val addressBook = addressBook.impl
 
         val connHandlerProtocols = protocols.values.mapNotNull { it as? ConnectionHandler }

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicKuboTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicKuboTestJava.java
@@ -23,6 +23,7 @@ public class QuicKuboTestJava {
     Host clientHost =
         new HostBuilder()
             //                .secureTransport(QuicTransport::Ed25519)
+            .keyType(KeyType.ED25519)
             .secureTransport(QuicTransport::Ecdsa)
             .build();
 

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
@@ -10,15 +10,12 @@ import io.libp2p.core.multiformats.*;
 import io.libp2p.core.mux.StreamMuxerProtocol;
 import io.libp2p.protocol.*;
 import io.libp2p.security.noise.NoiseXXSecureChannel;
-import io.libp2p.security.tls.TlsSecureChannel;
 import io.libp2p.transport.tcp.TcpTransport;
 import io.netty.handler.logging.LogLevel;
-
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
-
 import kotlin.*;
 import org.junit.jupiter.api.*;
 

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
@@ -13,11 +13,9 @@ import io.libp2p.security.noise.NoiseXXSecureChannel;
 import io.libp2p.security.tls.TlsSecureChannel;
 import io.libp2p.transport.tcp.TcpTransport;
 import io.netty.handler.logging.LogLevel;
-
 import java.util.Set;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
-
 import kotlin.*;
 import org.junit.jupiter.api.*;
 
@@ -29,12 +27,14 @@ public class QuicServerTestJava {
     Host clientHost =
         new HostBuilder()
             //                .secureTransport(QuicTransport::Ed25519)
+            .keyType(KeyType.ED25519)
             .secureTransport(QuicTransport::Ecdsa)
             .build();
 
     Host serverHost =
         new HostBuilder()
             //                .secureTransport(QuicTransport::Ed25519)
+            .keyType(KeyType.ED25519)
             .secureTransport(QuicTransport::Ecdsa)
             .protocol(new Ping())
             .listen(localListenAddress)
@@ -90,24 +90,26 @@ public class QuicServerTestJava {
     String localTcpListenAddress = "/ip4/127.0.0.1/tcp/40002";
 
     Host clientHost =
-            new HostBuilder()
-                    .secureTransport(QuicTransport::Ecdsa)
-                    .transport(TcpTransport::new)
-                    .secureChannel(TlsSecureChannel::ECDSA)
-                    .secureChannel(NoiseXXSecureChannel::new)
-                    .muxer(StreamMuxerProtocol::getYamux)
-                    .build();
+        new HostBuilder()
+            .keyType(KeyType.ED25519)
+            .secureTransport(QuicTransport::Ecdsa)
+            .transport(TcpTransport::new)
+            .secureChannel(TlsSecureChannel::ECDSA)
+            .secureChannel(NoiseXXSecureChannel::new)
+            .muxer(StreamMuxerProtocol::getYamux)
+            .build();
 
     Host serverHost =
-            new HostBuilder()
-                    .secureTransport(QuicTransport::Ecdsa)
-                    .transport(TcpTransport::new)
-                    .secureChannel(TlsSecureChannel::ECDSA)
-                    .secureChannel(NoiseXXSecureChannel::new)
-                    .muxer(StreamMuxerProtocol::getYamux)
-                    .protocol(new Ping())
-                    .listen(localQuicListenAddress, localTcpListenAddress)
-                    .build();
+        new HostBuilder()
+            .keyType(KeyType.ED25519)
+            .secureTransport(QuicTransport::Ecdsa)
+            .transport(TcpTransport::new)
+            .secureChannel(TlsSecureChannel::ECDSA)
+            .secureChannel(NoiseXXSecureChannel::new)
+            .muxer(StreamMuxerProtocol::getYamux)
+            .protocol(new Ping())
+            .listen(localQuicListenAddress, localTcpListenAddress)
+            .build();
 
     CompletableFuture<Void> clientStarted = clientHost.start();
     CompletableFuture<Void> serverStarted = serverHost.start();
@@ -119,17 +121,19 @@ public class QuicServerTestJava {
     Assertions.assertEquals(0, clientHost.listenAddresses().size());
     Assertions.assertEquals(2, serverHost.listenAddresses().size());
     Assertions.assertEquals(
-            Set.of(localTcpListenAddress + "/p2p/" + serverHost.getPeerId(), localQuicListenAddress + "/p2p/" + serverHost.getPeerId()),
-            serverHost.listenAddresses().stream().map(Multiaddr::toString).collect(Collectors.toSet()));
+        Set.of(
+            localTcpListenAddress + "/p2p/" + serverHost.getPeerId(),
+            localQuicListenAddress + "/p2p/" + serverHost.getPeerId()),
+        serverHost.listenAddresses().stream().map(Multiaddr::toString).collect(Collectors.toSet()));
     System.out.println("Hosts running");
     Thread.sleep(2_000);
 
     StreamPromise<PingController> tcpPing =
-            clientHost
-                    .getNetwork()
-                    .connect(serverHost.getPeerId(), new Multiaddr(localTcpListenAddress))
-                    .thenApply(it -> it.muxerSession().createStream(new Ping(500)))
-                    .get(5000, TimeUnit.SECONDS);
+        clientHost
+            .getNetwork()
+            .connect(serverHost.getPeerId(), new Multiaddr(localTcpListenAddress))
+            .thenApply(it -> it.muxerSession().createStream(new Ping(500)))
+            .get(5000, TimeUnit.SECONDS);
 
     Stream pingStream = tcpPing.getStream().get(5, TimeUnit.SECONDS);
     System.out.println("Ping stream created");
@@ -145,14 +149,14 @@ public class QuicServerTestJava {
     System.out.println("Ping stream closed");
 
     Assertions.assertThrows(
-            ExecutionException.class, () -> pingCtr.ping().get(5, TimeUnit.SECONDS));
+        ExecutionException.class, () -> pingCtr.ping().get(5, TimeUnit.SECONDS));
 
     StreamPromise<PingController> quicPing =
-            clientHost
-                    .getNetwork()
-                    .connect(serverHost.getPeerId(), new Multiaddr(localQuicListenAddress))
-                    .thenApply(it -> it.muxerSession().createStream(new Ping(500)))
-                    .get(5000, TimeUnit.SECONDS);
+        clientHost
+            .getNetwork()
+            .connect(serverHost.getPeerId(), new Multiaddr(localQuicListenAddress))
+            .thenApply(it -> it.muxerSession().createStream(new Ping(500)))
+            .get(5000, TimeUnit.SECONDS);
 
     Stream quicPingStream = quicPing.getStream().get(5, TimeUnit.SECONDS);
     System.out.println("Ping stream created");
@@ -168,7 +172,7 @@ public class QuicServerTestJava {
     System.out.println("Ping stream closed");
 
     Assertions.assertThrows(
-            ExecutionException.class, () -> quicPingCtr.ping().get(5, TimeUnit.SECONDS));
+        ExecutionException.class, () -> quicPingCtr.ping().get(5, TimeUnit.SECONDS));
 
     clientHost.stop().get(5, TimeUnit.SECONDS);
     System.out.println("Client stopped");
@@ -183,6 +187,7 @@ public class QuicServerTestJava {
 
     Host clientHost =
         new HostBuilder()
+            .keyType(KeyType.ED25519)
             .secureTransport(QuicTransport::Ecdsa)
             .builderModifier(
                 b -> b.getDebug().getMuxFramesHandler().addCompactLogger(LogLevel.ERROR, "client"))
@@ -190,6 +195,7 @@ public class QuicServerTestJava {
 
     Host serverHost =
         new HostBuilder()
+            .keyType(KeyType.ED25519)
             .secureTransport(QuicTransport::Ecdsa)
             .protocol(new Blob(blobSize))
             .listen(localListenAddress)
@@ -242,10 +248,15 @@ public class QuicServerTestJava {
   void addPingAfterHostStart() throws Exception {
     String localListenAddress = "/ip4/127.0.0.1/udp/40002/quic";
 
-    Host clientHost = new HostBuilder().secureTransport(QuicTransport::Ecdsa).build();
+    Host clientHost =
+        new HostBuilder().keyType(KeyType.ED25519).secureTransport(QuicTransport::Ecdsa).build();
 
     Host serverHost =
-        new HostBuilder().secureTransport(QuicTransport::Ecdsa).listen(localListenAddress).build();
+        new HostBuilder()
+            .keyType(KeyType.ED25519)
+            .secureTransport(QuicTransport::Ecdsa)
+            .listen(localListenAddress)
+            .build();
 
     CompletableFuture<Void> clientStarted = clientHost.start();
     CompletableFuture<Void> serverStarted = serverHost.start();


### PR DESCRIPTION

We definitely need to redesign Transport constructors in the presence of a new transport type which encapsulates both security and muxer. 
But for now I'd suggest this refactor to slightly reduce the chaos with transport ctors 